### PR TITLE
debug 'Fatal call has possible formatting directive %v'

### DIFF
--- a/concurrency-patterns-in-go/queuing/buffering_test.go
+++ b/concurrency-patterns-in-go/queuing/buffering_test.go
@@ -21,7 +21,7 @@ func BenchmarkBufferedWrite(b *testing.B) {
 func tmpFileOrFatal() *os.File {
 	file, err := ioutil.TempFile("", "tmp")
 	if err != nil {
-		log.Fatal("error: %v", err)
+		log.Fatalf("error: %v", err)
 	}
 	return file
 }


### PR DESCRIPTION
I found build failed in this line.
Here shows 'Fatal call has possible formatting directive %v'