### PR TITLE
Make New method thread-safe in fig-sync-pool.go

### DIFF
--- a/gos-concurrency-building-blocks/the-sync-package/pool/fig-sync-pool.go
+++ b/gos-concurrency-building-blocks/the-sync-package/pool/fig-sync-pool.go
@@ -7,9 +7,12 @@ import (
 
 func main() {
 	var numCalcsCreated int
+	var m sync.Mutex
 	calcPool := &sync.Pool{
 		New: func() interface{} {
+			m.Lock()
 			numCalcsCreated += 1
+			m.Unlock()
 			mem := make([]byte, 1024)
 			return &mem // <1>
 		},


### PR DESCRIPTION
We used a counter to count the number of instances
created and that needs to be protected around a
mutex to make it thread safe.