### PR TITLE
`for` loop update Go.v1.22

### DIFF
--- a/gos-concurrency-building-blocks/goroutines/fig-goroutine-closure-loop-correct.go
+++ b/gos-concurrency-building-blocks/goroutines/fig-goroutine-closure-loop-correct.go
@@ -5,14 +5,17 @@ import (
 	"sync"
 )
 
+// This will works fine on Go.v1.22 (range notes part)
+// See docs for details : https://tip.golang.org/doc/go1.22
 func main() {
 	var wg sync.WaitGroup
+	// This code will not cause a race condition, since `salutation` is a new variable for each iteration of the range loop.
 	for _, salutation := range []string{"hello", "greetings", "good day"} {
 		wg.Add(1)
-		go func(salutation string) { // <1>
+		go func() {
 			defer wg.Done()
 			fmt.Println(salutation)
-		}(salutation) // <2>
+		}()
 	}
 	wg.Wait()
 }


### PR DESCRIPTION
Previously, the variables declared by a “for” loop were created once and updated by each iteration. In Go 1.22, each iteration of the loop creates new variables, to avoid accidental sharing bugs.
see docs: [go1.22](https://tip.golang.org/doc/go1.22)